### PR TITLE
broadcastEvents optimization

### DIFF
--- a/src/NostrRelayManager.cpp
+++ b/src/NostrRelayManager.cpp
@@ -119,11 +119,11 @@ void NostrRelayManager::broadcastEventToRelay(String serializedEventJson, String
  * 
  */
 void NostrRelayManager::broadcastEvents() {
-
-  unsigned long currentMillis = millis();
   if (m_queue.isEmpty()) {
     return;
   }
+
+  unsigned long currentMillis = millis();
 
   if (connectedRelayCount() >= minRelays && currentMillis - lastBroadcastAttempt <= minRelaysTimeout) {
     // Broadcast all queued events to connected relays


### PR DESCRIPTION
As most of the time `broadcastEvents` will be ran with an empty queue, let's not get `currentMillis` until we know we're going to do something with it.

This function can be executed thousands of times per minute, so I think the optimization may be worth.