### PR TITLE
Update event callbacks in examples

### DIFF
--- a/examples/LilyGoTDisplay/LilyGoTDisplay.ino
+++ b/examples/LilyGoTDisplay/LilyGoTDisplay.ino
@@ -107,8 +107,8 @@ void setup() {
 
   // Set some event specific callbacks here
   nostrRelayManager.setEventCallback("ok", okEvent);
-  nostrRelayManager.setEventCallback("nip01", nip01Event);
-  nostrRelayManager.setEventCallback("nip04", nip04Event);
+  nostrRelayManager.setEventCallback(1, nip01Event);
+  nostrRelayManager.setEventCallback(4, nip04Event);
 
   nostrRelayManager.connect();
 

--- a/examples/Simple/Simple.ino
+++ b/examples/Simple/Simple.ino
@@ -86,8 +86,8 @@ void setup() {
 
   // Set some event specific callbacks here
   nostrRelayManager.setEventCallback("ok", okEvent);
-  nostrRelayManager.setEventCallback("nip01", nip01Event);
-  nostrRelayManager.setEventCallback("nip04", nip04Event);
+  nostrRelayManager.setEventCallback(1, nip01Event);
+  nostrRelayManager.setEventCallback(4, nip04Event);
 
   nostrRelayManager.connect();
 


### PR DESCRIPTION
This PR updates the event callback signature in the Simple and LilyGoTDisplay examples to match that of SubscribeRequest. It fixed the bug in Simple but it's untested on LilyGoTDisplay as I don't have a dev board with display. 